### PR TITLE
compute current stage from start of chain during initNext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.nishgpt</groupId>
   <artifactId>chain-executor</artifactId>
-  <version>0.0.4</version>
+  <version>0.0.5-RC</version>
 
   <licenses>
     <license>

--- a/src/main/java/com/github/nishgpt/chainexecutor/StageExecutionManager.java
+++ b/src/main/java/com/github/nishgpt/chainexecutor/StageExecutionManager.java
@@ -143,11 +143,15 @@ public abstract class StageExecutionManager<T extends Stage, U extends Execution
         return finishExecution(context);
       }
 
-      StageExecutor executor = getExecutor(nextStage, stageExecutorKey.getAuxiliaryKey());
+      // Computing the current stage from start of chain.
+      // Stage validation may have caused change in state for prior stages as well.
+      final var currentStage = getFirstNonCompletedStage(chainIdentifier, context, stageExecutorKey.getAuxiliaryKey());
+      StageExecutor executor = getExecutor(currentStage, stageExecutorKey.getAuxiliaryKey());
+
       //If stage is not initiated, call init
       if (executor.getStageStatus(context)
               .isNotInitiated()) {
-        log.info("Initiating {} Stage for id - {}", nextStage, context.getId());
+        log.info("Initiating {} Stage for id - {}", currentStage, context.getId());
         context = (U) executor.init(context);
       }
 


### PR DESCRIPTION
During init next we validate the stages from start , Once we have a stage which is not completed or skipped. We need to re-iterate from start to get the first non completed stage because the validation could have led to changes in previous milestones as well