### PR TITLE
initNext logic revamp 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.nishgpt</groupId>
   <artifactId>chain-executor</artifactId>
-  <version>0.0.4</version>
+  <version>0.0.5-RC</version>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.nishgpt</groupId>
   <artifactId>chain-executor</artifactId>
-  <version>0.0.5-RC</version>
+  <version>0.0.5</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
Instead of blindly sweeping forward and initing next executable stage in the forward stages of chain, it will first sweep forward, validating stages and then freshly recomputes next stage from start of chain